### PR TITLE
Ensure we don't call memcpy with a NULL pointer

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -267,7 +267,8 @@ static BN_ULONG *bn_expand_internal(const BIGNUM *b, int words)
     }
 
     assert(b->top <= words);
-    memcpy(a, b->d, sizeof(*a) * b->top);
+    if (b->top > 0)
+        memcpy(a, b->d, sizeof(*a) * b->top);
 
     return a;
 }
@@ -328,7 +329,8 @@ BIGNUM *BN_copy(BIGNUM *a, const BIGNUM *b)
     if (bn_wexpand(a, b->top) == NULL)
         return NULL;
 
-    memcpy(a->d, b->d, sizeof(b->d[0]) * b->top);
+    if (b->top > 0)
+        memcpy(a->d, b->d, sizeof(b->d[0]) * b->top);
 
     a->top = b->top;
     a->neg = b->neg;


### PR DESCRIPTION
Commit d5aa14dd simplified the bn_expand_internal() and BN_copy() functions.
Unfortunately it also removed some checks which are still required,
otherwise we call memcpy passing in NULL which is not allowed.

Reviewed-by: Tim Hudson <tjh@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/2836)

<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->
